### PR TITLE
Creating the `plantuml` subdirectory.

### DIFF
--- a/foliant/diagrams/plantuml.py
+++ b/foliant/diagrams/plantuml.py
@@ -2,6 +2,7 @@
 
 import subprocess
 from os.path import join
+from os import makedirs
 
 from colorama import Fore
 
@@ -15,6 +16,8 @@ def process_diagram(caption, body, src_dir, diag_dir_name, diag_id):
     and return the image ref."""
 
     diag_src_path = join(src_dir, diag_dir_name, SUBDIR_NAME, "%s.diag" % diag_id)
+
+    makedirs(join(src_dir, diag_dir_name, SUBDIR_NAME), exist_ok=True)
 
     with open(diag_src_path, 'w', encoding="utf8") as diag_src:
         diag_src.write(body)


### PR DESCRIPTION
In Foliant 0.4.7 PlantUML diagrams don’t work because Foliant 0.4.7 doesn’t create the subdirectory named `plantuml` inside the directory `foliantcache/diagrams`. My fix solves this problem.