### PR TITLE
Process pseudo XML tags more properly

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -26,3 +26,4 @@
 # 1.0.5
 
 -   Allow to override default config file name in CLI.
+-   Allow multiline tags. Process `true` and `false` attribute values as boolean, not as integer.

--- a/changelog.md
+++ b/changelog.md
@@ -1,20 +1,7 @@
-# 1.0.0
+# 1.0.5 (under development)
 
--   Complete rewrite.
-
-# 1.0.1
-
--   Fix critical bug with CLI module caused by missing version definition in the root `__init__.py` file.
-
-# 1.0.2
-
--   Use README.md as package description.
-
-
-# 1.0.3
-
--   Fix critical issue when config parsing would fail if any config value contained non-latin characters.
-
+-   Allow to override default config file name in CLI.
+-   Allow multiline tags. Process `true` and `false` attribute values as boolean, not as integer.
 
 # 1.0.4
 
@@ -22,8 +9,18 @@
 -   Add `pre` backend with `pre` target that applies the preprocessors from the config and returns a Foliant project that doesn't require any preprocessing.
 -   `make` now returns its result, which makes is easier to call it from extensions.
 
+# 1.0.3
 
-# 1.0.5
+-   Fix critical issue when config parsing would fail if any config value contained non-latin characters.
 
--   Allow to override default config file name in CLI.
--   Allow multiline tags. Process `true` and `false` attribute values as boolean, not as integer.
+# 1.0.2
+
+-   Use README.md as package description.
+
+# 1.0.1
+
+-   Fix critical bug with CLI module caused by missing version definition in the root `__init__.py` file.
+
+# 1.0.0
+
+-   Complete rewrite.

--- a/foliant/preprocessors/base.py
+++ b/foliant/preprocessors/base.py
@@ -42,9 +42,9 @@ class BasePreprocessor(object):
                 try:
                     return float(value)
                 except ValueError:
-                     try:
-                         return bool(strtobool(value))
-                     except ValueError:
+                    try:
+                        return bool(strtobool(value))
+                    except ValueError:
                         return value
 
         option_pattern = re.compile(

--- a/foliant/preprocessors/base.py
+++ b/foliant/preprocessors/base.py
@@ -42,12 +42,19 @@ class BasePreprocessor(object):
                 try:
                     return float(value)
                 except ValueError:
-                    try:
-                        return strtobool(value)
-                    except ValueError:
+                    if value.lower() == 'true':
+                        return True
+
+                    elif value.lower() == 'false':
+                        return False
+
+                    else:
                         return value
 
-        option_pattern = re.compile(r'(?P<key>\w+)="(?P<value>.+?)"')
+        option_pattern = re.compile(
+            r'(?P<key>\w+)="(?P<value>.+?)"',
+            flags=re.DOTALL
+        )
 
         return {
             option.group('key'): _cast_value(option.group('value'))
@@ -65,10 +72,10 @@ class BasePreprocessor(object):
 
         if self.tags:
             self.pattern = re.compile(
-                rf'(?<!\<)\<(?P<tag>{"|".join(self.tags)})'+
-                rf'(\s(?P<options>.*?))?\>'+
-                rf'(?P<body>.*?)\</(?P=tag)\>',
-                flags=re.MULTILINE|re.DOTALL
+                f'(?<!\<)\<(?P<tag>{"|".join(self.tags)})' +
+                f'(\s(?P<options>[^\<\>]*))?\>' +
+                f'(?P<body>.*?)\<\/(?P=tag)\>',
+                flags=re.DOTALL
             )
 
     def apply(self):

--- a/foliant/preprocessors/base.py
+++ b/foliant/preprocessors/base.py
@@ -42,17 +42,13 @@ class BasePreprocessor(object):
                 try:
                     return float(value)
                 except ValueError:
-                    if value.lower() == 'true':
-                        return True
-
-                    elif value.lower() == 'false':
-                        return False
-
-                    else:
+                     try:
+                         return bool(strtobool(value))
+                     except ValueError:
                         return value
 
         option_pattern = re.compile(
-            '(?P<key>[A-Za-z_:][0-9A-Za-z_:\-\.]*)="(?P<value>.+?)"',
+            r'(?P<key>[A-Za-z_:][0-9A-Za-z_:\-\.]*)="(?P<value>.+?)"',
             flags=re.DOTALL
         )
 
@@ -72,9 +68,9 @@ class BasePreprocessor(object):
 
         if self.tags:
             self.pattern = re.compile(
-                f'(?<!\<)\<(?P<tag>{"|".join(self.tags)})' +
-                f'(\s(?P<options>[^\<\>]*))?\>' +
-                f'(?P<body>.*?)\<\/(?P=tag)\>',
+                rf'(?<!\<)\<(?P<tag>{"|".join(self.tags)})' +
+                rf'(\s(?P<options>[^\<\>]*))?\>' +
+                rf'(?P<body>.*?)\<\/(?P=tag)\>',
                 flags=re.DOTALL
             )
 

--- a/foliant/preprocessors/base.py
+++ b/foliant/preprocessors/base.py
@@ -52,7 +52,7 @@ class BasePreprocessor(object):
                         return value
 
         option_pattern = re.compile(
-            r'(?P<key>\w+)="(?P<value>.+?)"',
+            '(?P<key>[A-Za-z_:][0-9A-Za-z_:\-\.]*)="(?P<value>.+?)"',
             flags=re.DOTALL
         )
 


### PR DESCRIPTION
Allow multiline tags. Process `true` and `false` attribute values as boolean, not as integer.

Valid tags examples:

```
<magick resize="600" background="Orange label:'Scheme 1' +swap" gravity="Center" append="append" output_format="jpg">
![Картинка](_img/pic.eps)
</magick>
```

```
<magick resize="600"
background="Orange label:'Scheme 2' +swap" gravity="Center"
append="True" output_format="jpg">
![Картинка](_img/pic.eps)
</magick>
```

```
<magick
command_params="-resize 600 \
-background Orange label:'Scheme 3' +swap \
-gravity Center \
-append"
output_format="jpg">
![Картинка](_img/pic.eps)
</magick>
```
