### PR TITLE
allow single and double quotes in tag params, add yaml tags

### DIFF
--- a/foliant/config/path.py
+++ b/foliant/config/path.py
@@ -4,6 +4,7 @@ from yaml import add_constructor
 
 from foliant.config.base import BaseParser
 
+
 class Parser(BaseParser):
     def _resolve_path_tag(self, _, node) -> str:
         '''Convert value after ``!path`` to an existing, absolute Posix path.
@@ -12,9 +13,23 @@ class Parser(BaseParser):
         '''
 
         path = Path(node.value).expanduser()
-        return (self.project_path/path).resolve(strict=True).as_posix()
+        return (self.project_path / path).resolve(strict=True).as_posix()
+
+    def _resolve_project_path_tag(self, _, node) -> str:
+        '''Convert value after ``!project_path`` to Path object relative to the
+        project path.
+        '''
+
+        return (self.project_path / node.value).absolute()
+
+    def _resolve_rel_path_tag(self, _, node) -> str:
+        '''Convert value after ``!rel_path`` to Path object.'''
+
+        return Path(node.value)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         add_constructor('!path', self._resolve_path_tag)
+        add_constructor('!project_path', self._resolve_project_path_tag)
+        add_constructor('!rel_path', self._resolve_rel_path_tag)

--- a/foliant/config/path.py
+++ b/foliant/config/path.py
@@ -18,9 +18,11 @@ class Parser(BaseParser):
     def _resolve_project_path_tag(self, _, node) -> str:
         '''Convert value after ``!project_path`` to Path object relative to the
         project path.
+
+        Return absolute path to this file without checks for existance.
         '''
 
-        return (self.project_path / node.value).absolute()
+        return (self.project_path / node.value).resolve()
 
     def _resolve_rel_path_tag(self, _, node) -> str:
         '''Convert value after ``!rel_path`` to Path object.'''

--- a/foliant/preprocessors/base.py
+++ b/foliant/preprocessors/base.py
@@ -1,6 +1,6 @@
 import re
+import yaml
 from logging import Logger
-from distutils.util import strtobool
 from typing import Dict
 OptionValue = int or float or bool or str
 
@@ -25,36 +25,13 @@ class BasePreprocessor(object):
         if not options_string:
             return {}
 
-        def _cast_value(value: str) -> OptionValue:
-            '''Attempt to convert a string to integer, float, or boolean.
-
-            If nothing matches, return the original string.
-
-            :param value: String to convert
-
-            :returns: Converted value or original string
-            '''
-
-            value = value.strip('"')
-
-            try:
-                return int(value)
-            except ValueError:
-                try:
-                    return float(value)
-                except ValueError:
-                    try:
-                        return bool(strtobool(value))
-                    except ValueError:
-                        return value
-
         option_pattern = re.compile(
-            r'(?P<key>[A-Za-z_:][0-9A-Za-z_:\-\.]*)="(?P<value>.+?)"',
+            r'(?P<key>[A-Za-z_:][0-9A-Za-z_:\-\.]*)=(\'|")(?P<value>.+?)\2',
             flags=re.DOTALL
         )
 
         return {
-            option.group('key'): _cast_value(option.group('value'))
+            option.group('key'): yaml.load(option.group('value'), yaml.Loader)
             for option in option_pattern.finditer(options_string)
         }
 


### PR DESCRIPTION
1. Allow tag params to be stated in either 'single quotes' or "double quotes".
2. Process tag params with yaml.load() instead of cast_value().
3. Add two new config tags:

!project_path — Path object relative to project root without validation.
!rel_path — just Path object, for preprocessors to treat like path relative to current file. This tag is necessary to interpret paths in tag parameters correct in includes.