### PR TITLE
add loader to all yaml.load calls

### DIFF
--- a/foliant/config/base.py
+++ b/foliant/config/base.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from logging import Logger
 
-from yaml import load
+from yaml import load, Loader
 
 
 class BaseParser(object):
@@ -28,7 +28,7 @@ class BaseParser(object):
         self.logger.info('Parsing started.')
 
         with open(self.config_path, encoding='utf8') as config_file:
-            config = {**self._defaults, **load(config_file)}
+            config = {**self._defaults, **load(config_file, Loader)}
 
             config['src_dir'] = Path(config['src_dir']).expanduser()
             config['tmp_dir'] = Path(config['tmp_dir']).expanduser()

--- a/foliant/config/include.py
+++ b/foliant/config/include.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from yaml import load, add_constructor
+from yaml import load, add_constructor, Loader
 
 from foliant.config.base import BaseParser
 
@@ -15,13 +15,13 @@ class Parser(BaseParser):
             path = Path(parts[0]).expanduser()
 
             with open(self.project_path/path) as include_file:
-                return load(include_file)
+                return load(include_file, Loader)
 
         elif len(parts) == 2:
             path, section = Path(parts[0]).expanduser(), parts[1]
 
             with open(self.project_path/path) as include_file:
-                return load(include_file)[section]
+                return load(include_file, Loader)[section]
 
         else:
             raise ValueError('Invalid include syntax')

--- a/tests/test_pre.py
+++ b/tests/test_pre.py
@@ -6,7 +6,7 @@ from os import chdir
 from collections import namedtuple
 
 from pytest import fixture
-from yaml import load
+from yaml import load, Loader
 
 from foliant.cli import Foliant
 
@@ -27,7 +27,7 @@ def build_project(request, datadir):
     )
 
     with open(project_path/'foliant.yml') as config:
-        yield BuiltProject(request.param, load(config)['title'], result)
+        yield BuiltProject(request.param, load(config, Loader)['title'], result)
 
 
 def test_dir_name(build_project):


### PR DESCRIPTION
In old PyYAML versions function `yaml.load` had default value for `loader` parameter equalilng `yaml.Loader`.
In new PyYAML 5.1 using `yaml.load` without specifying the `loader` parameter explicitly is not allowed anymore. In this pull request I added `loader=yaml.Loader` param to all `yaml.load` calls so now user can safely upgrade to PyYAML 5.1