### PR TITLE
Add support of the `escape_code` config option.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# 1.0.10 (under development)
+
+-   Add `escape_code` config option. To use it, escapecode and unescapecode preprocessors must be installed.
+
 # 1.0.9
 
 -   Process attribute values of pseudo-XML tags as YAML.

--- a/foliant/backends/base.py
+++ b/foliant/backends/base.py
@@ -93,12 +93,24 @@ class BaseBackend(object):
 
         copytree(src_path, self.working_dir)
 
-        preprocessors = (
+        common_preprocessors = (
             *self.required_preprocessors_before,
             *self.config.get('preprocessors', ()),
-            *self.required_preprocessors_after,
-            '_unescape'
+            *self.required_preprocessors_after
         )
+
+        if self.config.get('escape_code', False):
+            preprocessors = (
+                'escapecode',
+                *common_preprocessors,
+                'unescapecode'
+            )
+
+        else:
+            preprocessors = (
+                *common_preprocessors,
+                '_unescape'
+            )
 
         for preprocessor in preprocessors:
             self.apply_preprocessor(preprocessor)

--- a/foliant/config/base.py
+++ b/foliant/config/base.py
@@ -37,4 +37,10 @@ class BaseParser(object):
 
             self.logger.debug(f'Config: {config}')
 
+            if not config.get('escape_code', False):
+                self.logger.warning(
+                    'Working in backward compatibility mode. ' +
+                    'To get rid of this warning, enable the escape_code config option'
+                )
+
             return config


### PR DESCRIPTION
I’ve made two preprocessors that work in pair. They deprecate _unescape preprocessor. To use them, special flag must be set in config. Othervise, Foliant will work as earlier, in backward compatibility mode.

It would be right to maintain them as a part of Foliant core, but I develop them as a separate package for faster updates. In the same time, I’ve needed to integrate Foliant core and Includes with these preprocessors.

Details and examples you may see in the project’s README: https://github.com/foliant-docs/foliantcontrib.escapecode/blob/develop/README.md.

The work of the entire ecosystem including Foliant, Includes, EscapeCode/UnescapeCode, MultiProject extension has been comprehensively checked locally.