### PR TITLE
Add init extra that installs foliantcontrib.init.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,10 @@ python = "^3.6"
 pyyaml = "^5.1.1"
 cliar = "^1.3.2"
 prompt_toolkit = "^2.0"
+"foliantcontrib.init" = {version = "^1.0", optional = true}
+
+[tool.poetry.extras]
+init = ["foliantcontrib.init"]
 
 [tool.poetry.dev-dependencies]
 pytest = "^3.6"


### PR DESCRIPTION
With this extra, we can simplify Foliant installation instructions from `pip install foliant foliantcontrib.init` to `pip install foliant[init]`.