### PR TITLE
fix: python versions in the workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.8", "3.9" ]
+        python-version: [ "3.9", "3.10", "3.11" ]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION

---
## EntelligenceAI PR Summary 
 Updates CI/CD workflow to drop Python 3.8 support and test against Python 3.9, 3.10, and 3.11.
- Modified Python version matrix in GitHub Actions workflow configuration
- Removed Python 3.8 from test matrix
- Added Python 3.10 and 3.11 to test coverage
- Shifts minimum supported Python version from 3.8 to 3.9

---

## Confidence Score: 5/5 - Safe to Merge

- No review comments were generated, indicating the PR appears clean
- Zero critical, significant, or high-risk issues detected by automated analysis
- No existing unresolved comments that would block merging
- Heuristic analysis suggests maximum safety score of 5/5