### PR TITLE
fix: poetry_version format

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -62,7 +62,7 @@ jobs:
         - name: Build and publish to pypi
           uses: JRubics/poetry-publish@v1.11
           with:
-            poetry_version: 2.1.1
+            poetry_version: ==2.1.1
             pypi_token: ${{ secrets.PYPI_TOKEN }}
 
 


### PR DESCRIPTION

---
## EntelligenceAI PR Summary 
 This PR enforces strict Poetry version pinning in the PyPI publishing workflow by adding an explicit equality operator.
- Changed `poetry_version` parameter from `2.1.1` to `==2.1.1` in `.github/workflows/python-publish.yml`
- Ensures exact version 2.1.1 is used, preventing implicit version resolution
- Improves CI/CD pipeline reliability and predictability 


---

## Confidence Score: 5/5 - Safe to Merge

- No review comments were generated, indicating the PR passed automated checks cleanly
- Heuristic analysis shows zero critical, significant, high-risk, medium, or low severity issues
- No existing unresolved comments that would block merging
- The PR appears to be safe to merge as-is based on all available indicators
